### PR TITLE
Added no-privilege-scc gatekeeper policy

### DIFF
--- a/open-policy-agent/authorization/no-priv-scc/constraint.yaml
+++ b/open-policy-agent/authorization/no-priv-scc/constraint.yaml
@@ -1,0 +1,17 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoPrivScc
+metadata:
+  name: no-privileged-sccs
+spec:
+  match:
+    kinds:
+      - apiGroups: ["security.openshift.io"]
+        kinds: ["SecurityContextConstraints"]
+  parameters:
+    allowedUsers:
+      - "system:admin"
+      - "system:serviceaccount:openshift-infra:build-controller"
+    allowedGroups:
+      - "system:cluster-admins"
+      - "system:nodes"
+      - "system:masters"

--- a/open-policy-agent/authorization/no-priv-scc/template.yaml
+++ b/open-policy-agent/authorization/no-priv-scc/template.yaml
@@ -1,0 +1,37 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8snoprivscc
+  annotations:
+    description: Requires service accounts to not run using the privileged SCC.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sNoPrivScc
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8snoprivscc
+
+        violation[{"msg": msg}] {
+          input.review.object.kind == "SecurityContextConstraints"
+          input.review.object.metadata.name == "privileged"
+          re_match("^(security.openshift.io)/", input.review.object.apiVersion)
+          allowedUsers := { user | user := input.parameters.allowedUsers[_]}
+          presentUsers := {user | user := input.review.object.users[_]}
+          forbiddenUsers := presentUsers - allowedUsers
+          count(forbiddenUsers) > 0
+          msg := sprintf("Adding service accounts to the privileged SCC is not allowed. The user %v can not be associated with the privileged SCC.", [forbiddenUsers])
+        }
+
+        violation[{"msg": msg}] {
+          input.review.object.kind == "SecurityContextConstraints"
+          input.review.object.metadata.name == "privileged"
+          re_match("^(security.openshift.io)/", input.review.object.apiVersion)
+          allowedGroups := { group | group := input.parameters.allowedGroups[_]}
+          presentGroups := { group | group := input.review.object.groups[_]}
+          forbiddenGroups := presentGroups - allowedGroups
+          count(forbiddenGroups) > 0
+          msg := sprintf("Adding groups to the privileged SCC is not allowed. The group %v can not be associated with the privileged SCC.", [forbiddenGroups])
+        }


### PR DESCRIPTION
A gatekeeper policy that does not allow any user or group besides the default ones to be associated with the 'privileged' SCC.