### PR TITLE
Added the "Disallow self provisioner ClusterRole"  gatekeeper policy

### DIFF
--- a/open-policy-agent/resource-exhaustion/disallow-self-provisioner/constraint.yaml
+++ b/open-policy-agent/resource-exhaustion/disallow-self-provisioner/constraint.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDisallowSelfProvisioner
+metadata:
+  name: no-self-provisioner
+spec:
+  match:
+    kinds:
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        kinds: ["ClusterRoleBinding"]

--- a/open-policy-agent/resource-exhaustion/disallow-self-provisioner/template.yaml
+++ b/open-policy-agent/resource-exhaustion/disallow-self-provisioner/template.yaml
@@ -1,0 +1,21 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdisallowselfprovisioner
+  annotations:
+    description: Disallows self provisioner role to all users.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDisallowSelfProvisioner
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sdisallowselfprovisioner
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "ClusterRoleBinding"
+          input.review.object.metadata.name == "self-provisioners"
+          count(input.review.object.subjects) > 0
+          msg := sprintf("Adding the self-provisioner ClusterRole to users / groups is forbidden. %v can not be added to the self-provisioner ClusterRole", [input.review.object.subjects[_].name])
+        }

--- a/open-policy-agent/resource-exhaustion/disallow-self-provisioner/template.yaml
+++ b/open-policy-agent/resource-exhaustion/disallow-self-provisioner/template.yaml
@@ -15,7 +15,8 @@ spec:
         package k8sdisallowselfprovisioner
         violation[{"msg": msg}] {
           input.review.kind.kind == "ClusterRoleBinding"
-          input.review.object.metadata.name == "self-provisioners"
+          input.review.object.roleRef.kind == "ClusterRole"
+          input.review.object.roleRef.name == "self-provisioner"
           count(input.review.object.subjects) > 0
-          msg := sprintf("Adding the self-provisioner ClusterRole to users / groups is forbidden. %v can not be added to the self-provisioner ClusterRole", [input.review.object.subjects[_].name])
+          msg := sprintf("Adding the self-provisioner ClusterRole to users / groups is forbidden. The subjects specified in %v can not be added to the self-provisioner ClusterRole", [input.review.object.metadata.name])
         }


### PR DESCRIPTION
Gatekeeper monitors the self-provisioners ClusterRoleBinding, and does not allow any subjects to be attached to it.