### PR TITLE
Added a gatekeeper policy that controls the expiration time of oauth tokens

### DIFF
--- a/open-policy-agent/authentication-user-management/shorten-tokens/constraint.yaml
+++ b/open-policy-agent/authentication-user-management/shorten-tokens/constraint.yaml
@@ -1,0 +1,11 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sShortenToken
+metadata:
+  name: shorten-oauth-token
+spec:
+  match:
+    kinds:
+      - apiGroups: ["config.openshift.io"]
+        kinds: ["OAuth"]
+  parameters:
+    maxTokenTime: 29000 # 8 hours

--- a/open-policy-agent/authentication-user-management/shorten-tokens/template.yaml
+++ b/open-policy-agent/authentication-user-management/shorten-tokens/template.yaml
@@ -27,7 +27,7 @@ spec:
           input.review.object.metadata.name == "cluster"
           oauth := input.review.object
           not oauth_token(oauth)
-          msg := sprintf("The OAuth CR token lifespace was set to 86400, while it must be shorter than %v, refer to 'https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html' for more information", [input.parameters.maxTokenTime])
+          msg := sprintf("The OAuth CR token lifespace was set to 86400, while it must be shorter than %v, refer to 'https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html#oauth-configuring-internal-oauth_configuring-internal-oauth' for more information", [input.parameters.maxTokenTime])
         }
 
         oauth_token(oauth) = true {

--- a/open-policy-agent/authentication-user-management/shorten-tokens/template.yaml
+++ b/open-policy-agent/authentication-user-management/shorten-tokens/template.yaml
@@ -1,0 +1,36 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sshortentoken
+  annotations:
+    description: Shorten the default Access Token Lifespan.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sShortenToken
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package K8sShortenToken
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "OAuth"
+          input.review.object.metadata.name == "cluster"
+          oauth := input.review.object
+          oauth.spec.tokenConfig.accessTokenMaxAgeSeconds > input.parameters.maxTokenTime
+          msg := sprintf("The OAuth CR token lifespace was set to %v, while it must be shorter than %v", [oauth.spec.tokenConfig.accessTokenMaxAgeSeconds, input.parameters.maxTokenTime])
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "OAuth"
+          input.review.object.metadata.name == "cluster"
+          oauth := input.review.object
+          not oauth_token(oauth)
+          msg := sprintf("The OAuth CR token lifespace was set to 86400, while it must be shorter than %v, refer to 'https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html' for more information", [input.parameters.maxTokenTime])
+        }
+
+        oauth_token(oauth) = true {
+          oauth.spec["tokenConfig"]
+          count(oauth.spec.tokenConfig) > 0
+        }


### PR DESCRIPTION
The policy does not allow the default 24h token expiration time. By default, gatekeeper will deny setting the expiration time for oauth tokens above 8 hours.