### PR TITLE
Added a gatekeeper policy that verifies etcd encryption

### DIFF
--- a/open-policy-agent/README.md
+++ b/open-policy-agent/README.md
@@ -28,7 +28,7 @@ Policy  | Description | Prerequisites
 ### ETCD Security
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
-No policies yet
+[verify-etcd-encryption](./etcd-security/verify-etcd-encryption) | Ensures that the etcd is encrypted properly |
 
 ### Infrastructure General
 Policy  | Description | Prerequisites

--- a/open-policy-agent/etcd-security/verify-etcd-encryption/constraint.yaml
+++ b/open-policy-agent/etcd-security/verify-etcd-encryption/constraint.yaml
@@ -1,0 +1,10 @@
+
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sEtcdEncryptionVerification
+metadata:
+  name: verify-etcd-encryption
+spec:
+  match:
+    kinds:
+      - apiGroups: ["config.openshift.io"]
+        kinds: ["APIServer"]

--- a/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
+++ b/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
@@ -35,10 +35,12 @@ spec:
 
         # Prevents "encryption: {}"
         violation[{"msg": msg}] {
-          input.kind == "APIServer"
-          input.metadata.name == "cluster"
+          input.review.kind.kind == "APIServer"
+          input.review.object.metadata.name == "cluster"
 
-          missing(input.spec.encryption, "type")
+          etcd := input.review.object
+
+          missing(etcd.spec.encryption, "type")
 
           msg := "Etcd not encrypted, missing 'type' in apiserver object's spec.encryption"
         }

--- a/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
+++ b/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
@@ -1,0 +1,46 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8setcdencryptionverification
+  annotations:
+    description: Verify Etcd Encryption.
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sEtcdEncryptionVerification
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package K8sEtcdEncryptionVerification
+
+        missing(obj, field) = true {
+          not obj[field]
+        }
+        
+        missing(obj, field) = true {
+          obj[field] == ""
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "APIServer"
+          input.review.object.metadata.name == "cluster"
+
+          etcd := input.review.object
+
+          missing(etcd.spec, "encryption")
+
+          msg := "Etcd not encrypted, missing 'encryption' in apiserver object's spec"
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "APIServer"
+          input.review.object.metadata.name == "cluster"
+
+          etcd := input.review.object
+
+          # AES-CBC, PKCS#7 padding, 32-byte key
+          etcd.spec.encryption.type != "aescbc" 
+          
+          msg := "Etcd not encrypted properly, 'spec.encryption.type' should be 'aescbc'"
+        }

--- a/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
+++ b/open-policy-agent/etcd-security/verify-etcd-encryption/template.yaml
@@ -33,6 +33,16 @@ spec:
           msg := "Etcd not encrypted, missing 'encryption' in apiserver object's spec"
         }
 
+        # Prevents "encryption: {}"
+        violation[{"msg": msg}] {
+          input.kind == "APIServer"
+          input.metadata.name == "cluster"
+
+          missing(input.spec.encryption, "type")
+
+          msg := "Etcd not encrypted, missing 'type' in apiserver object's spec.encryption"
+        }
+
         violation[{"msg": msg}] {
           input.review.kind.kind == "APIServer"
           input.review.object.metadata.name == "cluster"


### PR DESCRIPTION
Tested in multiple environments: 
1. Completly non-encrypted ETCD - triggers a dedicated violation 
2. ETCD Encrypted with "identity" as type - triggers a dedicated violation 
3. ETCD Encrypted with "aescbc" as type - does not trigger a violation 