### PR TITLE
- Kyverno policy protect-default-scc

### DIFF
--- a/kyverno/README.md
+++ b/kyverno/README.md
@@ -18,14 +18,17 @@ The solution presented in this directory is designed to provide compliance for  
 ### Authentication and User Management
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+No policies yet       |  | 
 
 ### Authorization
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+[protect-default-scc](./authorization/protect-default-scc.yaml) | Ensures that default scc are not being modified or deleted |
 
 ### ETCD Security
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+No policies yet       |  | 
 
 ### Infrastructure General
 Policy  | Description | Prerequisites
@@ -40,10 +43,12 @@ No policies yet       |  |
 ### Networking
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+No policies yet       |  | 
 
 ### Resource Exhaustion
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+No policies yet       |  | 
 
 ### Storage
 Policy  | Description | Prerequisites
@@ -53,3 +58,13 @@ No policies yet       |  |
 ### Trusted Image Sources
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
+No policies yet       |  | 
+
+## Applying Policies
+The policies can be created by applying the custom resources defined in the cluster policy 'yaml' files to an OpenShift cluster. The files are provided in each policy directory under specific security control.
+
+For example, applying 'protect-default-scc' policy which prevents from default OpenShift scc to be modified or deleted by users
+
+```
+$ oc apply -f https://raw.githubusercontent.com/openshift-4-compliance/openshift-4-compliance-automation/master/kyverno/authentication-user-management/protect-default-scc.yaml
+```

--- a/kyverno/authentication-user-management/protect-default-scc.yaml
+++ b/kyverno/authentication-user-management/protect-default-scc.yaml
@@ -1,0 +1,21 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: protect-default-scc
+spec:
+  background: true
+  validationFailureAction: enforce
+  rules:
+    - name: Prevent users from modifying or deleting default scc
+      match:
+        resources:
+          kinds:
+            - SecurityContextConstraints
+      exclude:
+        resources:
+          kinds:
+            - SecurityContextConstraints
+          name: "custom-scc-*"
+      validate:
+        message: "Modifying or deleting default scc is forbidden. You can create custom scc. The custom scc name syntax should begin with 'custom-scc-'"
+        deny: {}


### PR DESCRIPTION
- Kyverno policy that prevents default scc from being modified or deleted