### PR TITLE
Added shorten token lifespan policy for Red Hat Advanced Cluster Management

### DIFF
--- a/redhat-acm/README.md
+++ b/redhat-acm/README.md
@@ -20,6 +20,7 @@ Policy  | Description | Prerequisites
 ------- | ----------- | -------------
 [kubeadmin-policy](./authentication-user-management/kubeadmin-policy.yml) | Validates the removal of the kubeadmin temporary user |
 [group-policy](./authentication-user-management/group-policy.yml) | Ensures that a group is created with the defined users in it |
+[gatekeeper-shorten-tokens](./authentication-user-management/gatekeeper-shorten-tokens.yaml) | Ensure that authentication tokens have a restricted lifespan | 
 
 ### Authorization
 Policy  | Description | Prerequisites

--- a/redhat-acm/authentication-user-management/gatekeeper-shorten-tokens.yaml
+++ b/redhat-acm/authentication-user-management/gatekeeper-shorten-tokens.yaml
@@ -1,0 +1,132 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: policy-gatekeeper-shorten-tokens
+  annotations:
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-shorten-tokens
+        spec:
+          remediationAction: enforce
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: templates.gatekeeper.sh/v1beta1
+                kind: ConstraintTemplate
+                metadata:
+                  name: k8sshortentoken
+                  annotations:
+                    description: Shorten the default Access Token Lifespan.
+                spec:
+                  crd:
+                    spec:
+                      names:
+                        kind: K8sShortenToken
+                  targets:
+                    - target: admission.k8s.gatekeeper.sh
+                      rego: |
+                        package K8sShortenToken
+                        violation[{"msg": msg}] {
+                          input.review.kind.kind == "OAuth"
+                          input.review.object.metadata.name == "cluster"
+                          oauth := input.review.object
+                          oauth.spec.tokenConfig.accessTokenMaxAgeSeconds > input.parameters.maxTokenTime
+                          msg := sprintf("The OAuth CR token lifespace was set to %v, while it must be shorter than %v", [oauth.spec.tokenConfig.accessTokenMaxAgeSeconds, input.parameters.maxTokenTime])
+                        }
+                        violation[{"msg": msg}] {
+                          input.review.kind.kind == "OAuth"
+                          input.review.object.metadata.name == "cluster"
+                          oauth := input.review.object
+                          not oauth_token(oauth)
+                          msg := sprintf("The OAuth CR token lifespace was set to 86400, while it must be shorter than %v, refer to 'https://docs.openshift.com/container-platform/4.6/authentication/configuring-internal-oauth.html#oauth-configuring-internal-oauth_configuring-internal-oauth' for more information", [input.parameters.maxTokenTime])
+                        }
+                        oauth_token(oauth) = true {
+                          oauth.spec["tokenConfig"]
+                          count(oauth.spec.tokenConfig) > 0
+                        }
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: K8sShortenToken
+                metadata:
+                  name: shorten-oauth-token
+                spec:
+                  match:
+                    kinds:
+                      - apiGroups: ["config.openshift.io"]
+                        kinds: ["OAuth"]
+                  parameters:
+                    maxTokenTime: 29000 # 8 hours
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-audit-shorten-tokens
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: constraints.gatekeeper.sh/v1beta1
+                kind: K8sShortenToken
+                metadata:
+                  name: shorten-oauth-token
+                status:
+                  totalViolations: 0
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-admission-shorten-tokens
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Event
+                metadata:
+                  namespace: openshift-gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
+                  annotations:
+                    constraint_action: deny
+                    constraint_kind: K8sShortenToken
+                    constraint_name: shorten-oauth-token
+                    event_type: violation
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-policy-gatekeeper-shorten-tokens
+placementRef:
+  name: placement-policy-gatekeeper-shorten-tokens
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: policy-gatekeeper-shorten-tokens
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-policy-gatekeeper-shorten-tokens
+spec:
+  clusterConditions:
+    - status: "True"
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - { key: environment, operator: In, values: ["dev"] }

--- a/redhat-acm/kustomization.yaml
+++ b/redhat-acm/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - ./resource-exhaustion/disallow-self-provisioner-policy.yml
 - ./trusted-image-sources/gatekeeper-disallow-image-tags.yml
 - ./authentication-user-management/kubeadmin-policy.yml
+- ./authentication-user-management/gatekeeper-shorten-tokens.yaml


### PR DESCRIPTION
Added a policy for Red Hat Advanced Cluster Management. 

The policy makes sure that the default access token have a short lifespan. The token's lifespan limit is set to 8 hours by default.