### PR TITLE
Fixed disallow-privileged-scc-usage Gatekeeper policy

### DIFF
--- a/open-policy-agent/README.md
+++ b/open-policy-agent/README.md
@@ -24,7 +24,7 @@ Policy  | Description | Prerequisites
 ### Authorization
 Policy  | Description | Prerequisites
 ------- | ----------- | -------------
-[no-priv-scc](./authorization/no-priv-scc) | Ensures that privilged scc is not being used by unlisted Services |
+[disallow-privileged-scc-usage](./authorization/disallow-privileged-scc-usage) | Ensures that privilged scc is not being used by unlisted service accounts, users and groups |
 
 ### ETCD Security
 Policy  | Description | Prerequisites

--- a/open-policy-agent/authorization/README.md
+++ b/open-policy-agent/authorization/README.md
@@ -1,33 +1,3 @@
 # Gatekeeper Authrorization Policies
 
 This directory includes a list of Gatekeeper policies that focus on authorization in OpenShift.
-
-## [disallow-privileged-scc-usage](./disallow-privileged-scc-usage) 
-
-The policy disallows adding users, service accounts and groups to the `privileged` SecurityContextConstraints object. In order to assign a specific user to the `privileged` SecurityContextConstraints, make sure to exclude the entity in the policy's [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) object.
-
-To add the `foo` service account in the `bar` namespace to the `privileged` SecurityContextConstraints, modify the [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) file -
-
-```
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sNoPrivScc
-metadata:
-  name: no-privileged-sccs
-...
-  parameters:
-    allowedUsers:
-    ...
-      - "system:serviceaccount:bar:foo"
-    ...
-```
-
-After applying the updated `constraint.yaml` object, the service account could be added to the `privileged` SecurityContextConstraints by editing the object -
-```
-$ oc edit scc privileged
-
-...
-users:
-...
-- system:serviceaccount:bar:foo
-...
-```

--- a/open-policy-agent/authorization/README.md
+++ b/open-policy-agent/authorization/README.md
@@ -1,0 +1,33 @@
+# Gatekeeper Authrorization Policies
+
+This directory includes a list of Gatekeeper policies that focus on authorization in OpenShift.
+
+## [disallow-privileged-scc-usage](./disallow-privileged-scc-usage) 
+
+The policy disallows adding users, service accounts and groups to the `privileged` SecurityContextConstraints object. In order to assign a specific user to the `privileged` SecurityContextConstraints, make sure to exclude the entity in the policy's [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) object.
+
+To add the `foo` service account in the `bar` namespace to the `privileged` SecurityContextConstraints, modify the [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) file -
+
+```
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoPrivScc
+metadata:
+  name: no-privileged-sccs
+...
+  parameters:
+    allowedUsers:
+    ...
+      - "system:serviceaccount:bar:foo"
+    ...
+```
+
+After applying the updated `constraint.yaml` object, the service account could be added to the `privileged` SecurityContextConstraints by editing the object -
+```
+$ oc edit scc privileged
+
+...
+users:
+...
+- system:serviceaccount:bar:foo
+...
+```

--- a/open-policy-agent/authorization/disallow-privileged-scc-usage/README.md
+++ b/open-policy-agent/authorization/disallow-privileged-scc-usage/README.md
@@ -1,8 +1,8 @@
 # Disallow Privileged SCC Usage
 
-The policy disallows adding users, service accounts and groups to the `privileged` SecurityContextConstraints object. In order to assign a specific user to the `privileged` SecurityContextConstraints, make sure to exclude the entity in the policy's [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) object.
+The policy disallows adding users, service accounts and groups to the `privileged` SecurityContextConstraints object. In order to assign a specific user to the `privileged` SecurityContextConstraints, make sure to exclude the entity in the policy's [constraint.yaml](./constraint.yaml) object.
 
-To add the `foo` service account in the `bar` namespace to the `privileged` SecurityContextConstraints, modify the [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) file -
+To add the `foo` service account in the `bar` namespace to the `privileged` SecurityContextConstraints, modify the [constraint.yaml](./constraint.yaml) file -
 
 ```
 apiVersion: constraints.gatekeeper.sh/v1beta1

--- a/open-policy-agent/authorization/disallow-privileged-scc-usage/README.md
+++ b/open-policy-agent/authorization/disallow-privileged-scc-usage/README.md
@@ -1,0 +1,29 @@
+# Disallow Privileged SCC Usage
+
+The policy disallows adding users, service accounts and groups to the `privileged` SecurityContextConstraints object. In order to assign a specific user to the `privileged` SecurityContextConstraints, make sure to exclude the entity in the policy's [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) object.
+
+To add the `foo` service account in the `bar` namespace to the `privileged` SecurityContextConstraints, modify the [constraint.yaml](./disallow-privileged-scc-usage/constraint.yaml) file -
+
+```
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sNoPrivScc
+metadata:
+  name: no-privileged-sccs
+...
+  parameters:
+    allowedUsers:
+    ...
+      - "system:serviceaccount:bar:foo"
+    ...
+```
+
+After applying the updated `constraint.yaml` object, the service account could be added to the `privileged` SecurityContextConstraints by editing the object -
+```
+$ oc edit scc privileged
+
+...
+users:
+...
+- system:serviceaccount:bar:foo
+...
+```

--- a/open-policy-agent/authorization/disallow-privileged-scc-usage/constraint.yaml
+++ b/open-policy-agent/authorization/disallow-privileged-scc-usage/constraint.yaml
@@ -7,6 +7,8 @@ spec:
     kinds:
       - apiGroups: ["security.openshift.io"]
         kinds: ["SecurityContextConstraints"]
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        kinds: ["ClusterRoleBinding"]
   parameters:
     allowedUsers:
       - "system:admin"

--- a/open-policy-agent/authorization/disallow-privileged-scc-usage/template.yaml
+++ b/open-policy-agent/authorization/disallow-privileged-scc-usage/template.yaml
@@ -35,3 +35,11 @@ spec:
           count(forbiddenGroups) > 0
           msg := sprintf("Adding groups to the privileged SCC is not allowed. The group %v can not be associated with the privileged SCC.", [forbiddenGroups])
         }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "ClusterRoleBinding"
+          input.review.object.roleRef.kind == "ClusterRole"
+          input.review.object.roleRef.name == "system:openshift:scc:privileged"
+          count(input.review.object.subjects) > 0
+          msg := sprintf("Adding service accounts to the privileged SCC is not allowed. The user / group - %v can not be associated with the privileged SCC.", [input.review.object.subjects[_].name])
+        }


### PR DESCRIPTION
Added support to `oc` clients with the `4.5+` version.

Relevant issue at - https://github.com/openshift-4-compliance/openshift-4-compliance-automation/issues/20