### PR TITLE
Change enforcementAction to dryrun in Gatekeeper policies

### DIFF
--- a/open-policy-agent/authentication-user-management/shorten-tokens/constraint.yaml
+++ b/open-policy-agent/authentication-user-management/shorten-tokens/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sShortenToken
 metadata:
   name: shorten-oauth-token
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: ["config.openshift.io"]

--- a/open-policy-agent/authorization/disallow-privileged-scc-usage/constraint.yaml
+++ b/open-policy-agent/authorization/disallow-privileged-scc-usage/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sNoPrivScc
 metadata:
   name: no-privileged-sccs
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: ["security.openshift.io"]

--- a/open-policy-agent/authorization/prevent-default-serviceaccount-usage/constraint.yaml
+++ b/open-policy-agent/authorization/prevent-default-serviceaccount-usage/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sPreventDefaultServiceAccountUsage
 metadata:
   name: prevent-default-serviceaccount-usage
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: [""]

--- a/open-policy-agent/etcd-security/verify-etcd-encryption/constraint.yaml
+++ b/open-policy-agent/etcd-security/verify-etcd-encryption/constraint.yaml
@@ -4,6 +4,7 @@ kind: K8sEtcdEncryptionVerification
 metadata:
   name: verify-etcd-encryption
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: ["config.openshift.io"]

--- a/open-policy-agent/networking/block-nodeport-services/constraint.yaml
+++ b/open-policy-agent/networking/block-nodeport-services/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sBlockNodePort
 metadata:
   name: block-node-port
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: [""]

--- a/open-policy-agent/networking/external-ips/constraint.yaml
+++ b/open-policy-agent/networking/external-ips/constraint.yaml
@@ -4,6 +4,7 @@ kind: K8sExternalIPs
 metadata:
   name: external-ips
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: [""]

--- a/open-policy-agent/networking/httpsonly/constraint.yaml
+++ b/open-policy-agent/networking/httpsonly/constraint.yaml
@@ -4,6 +4,7 @@ kind: K8sHttpsOnly
 metadata:
   name: ingress-https-only
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: ["route.openshift.io"]

--- a/open-policy-agent/resource-exhaustion/disallow-self-provisioner/constraint.yaml
+++ b/open-policy-agent/resource-exhaustion/disallow-self-provisioner/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sDisallowSelfProvisioner
 metadata:
   name: no-self-provisioner
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: ["rbac.authorization.k8s.io"]

--- a/open-policy-agent/trusted-image-sources/disallowedtags/constraint.yaml
+++ b/open-policy-agent/trusted-image-sources/disallowedtags/constraint.yaml
@@ -3,6 +3,7 @@ kind: K8sDisallowedTags
 metadata:
   name: container-image-must-not-have-tags
 spec:
+  enforcementAction: dryrun
   match:
     kinds:
       - apiGroups: [""]


### PR DESCRIPTION
Changing the enforcement action in Gatekeeper policies to `dryrun`.

Reference to issue - https://github.com/openshift-4-compliance/openshift-4-compliance-automation/issues/86